### PR TITLE
replace costly modulo operation by cheap bitmask operation

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -34,8 +34,8 @@ where
     fn read_padding_of<T>(&mut self) -> Result<()> {
         // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte boundaries
         // Instead of using the slow modulo operation '%', the faster bit-masking is used
-        let alignment: usize = std::mem::size_of::<T>();
-        let rem_mask: usize = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
+        let alignment = std::mem::size_of::<T>();
+        let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
         let mut padding: [u8; 8] = [0; 8];
         match (self.pos as usize) & rem_mask {
             0 => Ok(()),

--- a/src/de.rs
+++ b/src/de.rs
@@ -32,10 +32,12 @@ where
     }
 
     fn read_padding_of<T>(&mut self) -> Result<()> {
-        let alignment = std::mem::size_of::<T>();
-        let mut padding = [0; 8];
-        self.pos %= 8;
-        match (self.pos as usize) % alignment {
+        // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte boundaries
+        // Instead of using the slow modulo operation '%', the faster bit-masking is used
+        let alignment: usize = std::mem::size_of::<T>();
+        let rem_mask: usize = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
+        let mut padding: [u8; 8] = [0; 8];
+        match (self.pos as usize) & rem_mask {
             0 => Ok(()),
             n @ 1...7 => {
                 let amt = alignment - n;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -48,8 +48,8 @@ where
         // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte boundaries
         // Instead of using the slow modulo operation '%', the faster bit-masking is used
         const PADDING: [u8; 8] = [0; 8];
-        let alignment: usize = std::mem::size_of::<T>();
-        let rem_mask: usize = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
+        let alignment = std::mem::size_of::<T>();
+        let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
         match (self.pos as usize) & rem_mask {
             0 => Ok(()),
             n @ 1...7 => {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -45,15 +45,17 @@ where
     }
 
     fn write_padding_of<T>(&mut self) -> Result<()> {
-        let alignment = std::mem::size_of::<T>();
-        let padding = [0; 8];
-        self.pos %= 8;
-        match (self.pos as usize) % alignment {
+        // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte boundaries
+        // Instead of using the slow modulo operation '%', the faster bit-masking is used
+        const PADDING: [u8; 8] = [0; 8];
+        let alignment: usize = std::mem::size_of::<T>();
+        let rem_mask: usize = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
+        match (self.pos as usize) & rem_mask {
             0 => Ok(()),
             n @ 1...7 => {
                 let amt = alignment - n;
                 self.pos += amt as u64;
-                self.writer.write_all(&padding[..amt]).map_err(Into::into)
+                self.writer.write_all(&PADDING[..amt]).map_err(Into::into)
             }
             _ => unreachable!(),
         }

--- a/src/size.rs
+++ b/src/size.rs
@@ -86,8 +86,8 @@ where
 
     fn add_padding_of<T>(&mut self) -> Result<()> {
         let alignment = std::mem::size_of::<T>();
-        self.pos %= 8;
-        match self.pos % alignment {
+        let rem_mask: usize = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
+        match (self.pos as usize) & rem_mask {
             0 => Ok(()),
             n @ 1...7 => {
                 let amt = alignment - n;

--- a/src/size.rs
+++ b/src/size.rs
@@ -86,7 +86,7 @@ where
 
     fn add_padding_of<T>(&mut self) -> Result<()> {
         let alignment = std::mem::size_of::<T>();
-        let rem_mask: usize = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
+        let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
         match (self.pos as usize) & rem_mask {
             0 => Ok(()),
             n @ 1...7 => {


### PR DESCRIPTION
Performance of CDR encoding deoends on the performance of the alignment routine. Instead of using costly modulo operation to calculate the 2^n boundary (1,2,4,8),  it is much cheaper to use bitmask-operations to mask out the corresponding lower bits of position counter.