### PR TITLE
Improve (de)serialization performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ travis-ci = { repository = "hrektts/cdr-rs" }
 
 [dependencies]
 byteorder = "1.2"
-failure = "0.1"
-failure_derive = "0.1"
 serde = "1.0"
 
 [dev-dependencies]

--- a/src/de.rs
+++ b/src/de.rs
@@ -5,7 +5,7 @@ use std::{self, io::Read, marker::PhantomData};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 use serde::de::{self, IntoDeserializer};
 
-use crate::error::{Error, ErrorKind, Result};
+use crate::error::{Error, Result};
 use crate::size::{Infinite, SizeLimit};
 
 /// A deserializer that reads bytes from a buffer.
@@ -64,7 +64,7 @@ where
             v.pop(); // removes a terminating null character
             v
         })?)
-        .map_err(|e| ErrorKind::InvalidUtf8Encoding(e.utf8_error()).into())
+        .map_err(|e| Error::InvalidUtf8Encoding(e.utf8_error()))
     }
 
     fn read_vec(&mut self) -> Result<Vec<u8>> {
@@ -93,7 +93,7 @@ where
     where
         V: de::Visitor<'de>,
     {
-        Err(ErrorKind::DeserializeAnyNotSupported.into())
+        Err(Error::DeserializeAnyNotSupported)
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -104,7 +104,7 @@ where
         match value {
             1 => visitor.visit_bool(true),
             0 => visitor.visit_bool(false),
-            value => Err(ErrorKind::InvalidBoolEncoding(value).into()),
+            value => Err(Error::InvalidBoolEncoding(value)),
         }
     }
 
@@ -205,7 +205,7 @@ where
 
         let width = utf8_char_width(buf[0]);
         if width != 1 {
-            Err(ErrorKind::InvalidCharEncoding.into())
+            Err(Error::InvalidCharEncoding)
         } else {
             self.read_size(width as u64)?;
             visitor.visit_char(buf[0] as char)
@@ -244,7 +244,7 @@ where
     where
         V: de::Visitor<'de>,
     {
-        Err(ErrorKind::TypeNotSupported.into())
+        Err(Error::TypeNotSupported)
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
@@ -338,7 +338,7 @@ where
     where
         V: de::Visitor<'de>,
     {
-        Err(ErrorKind::TypeNotSupported.into())
+        Err(Error::TypeNotSupported)
     }
 
     fn deserialize_struct<V>(
@@ -388,14 +388,14 @@ where
     where
         V: de::Visitor<'de>,
     {
-        Err(ErrorKind::TypeNotSupported.into())
+        Err(Error::TypeNotSupported)
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
-        Err(ErrorKind::TypeNotSupported.into())
+        Err(Error::TypeNotSupported)
     }
 
     fn is_human_readable(&self) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,34 +5,59 @@ use std::{
     str::Utf8Error,
 };
 
-use failure::{Context, Fail};
-use serde;
-
 /// Convenient wrapper around `std::Result`.
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// The Error type.
 #[derive(Debug)]
-pub struct Error {
-    inner: Context<ErrorKind>,
-}
-
-impl Error {
-    pub fn kind_ref(&self) -> &ErrorKind {
-        self.inner.get_context()
-    }
+pub enum Error {
+    Message(String),
+    Io(io::Error),
+    DeserializeAnyNotSupported,
+    InvalidBoolEncoding(u8),
+    InvalidChar(char),
+    InvalidCharEncoding,
+    InvalidEncapsulation,
+    InvalidUtf8Encoding(Utf8Error),
+    NumberOutOfRange,
+    SequenceMustHaveLength,
+    SizeLimit,
+    TypeNotSupported,
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self.inner, f)
+        use Error::*;
+
+        match *self {
+            Message(ref msg) => Display::fmt(msg, f),
+            Io(ref err) => Display::fmt(err, f),
+            DeserializeAnyNotSupported => write!(
+                f,
+                "does not support the serde::Deserializer::deserialize_any method"
+            ),
+            InvalidBoolEncoding(v) => write!(f, "expected 0 or 1, found {}", v),
+            InvalidChar(v) => write!(f, "expected char of width 1, found {}", v),
+            InvalidCharEncoding => write!(f, "char is not valid UTF-8"),
+            InvalidEncapsulation => write!(f, "encapsulation is not valid"),
+            InvalidUtf8Encoding(ref err) => Display::fmt(err, f),
+            NumberOutOfRange => write!(f, "sequence is too long"),
+            SequenceMustHaveLength => {
+                write!(f, "sequences must have a knowable size ahead of time")
+            }
+            SizeLimit => write!(f, "the size limit has been reached"),
+            TypeNotSupported => write!(f, "unsupported type"),
+        }
     }
 }
 
 impl std::error::Error for Error {
     fn description(&self) -> &str {
-        match *self.inner.get_context() {
-            ErrorKind::Io(ref err) => std::error::Error::description(err),
+        use Error::*;
+
+        match *self {
+            Io(ref err) => err.description(),
+            InvalidUtf8Encoding(ref err) => err.description(),
             _ => {
                 // If you want a better message, use Display::fmt or to_string().
                 "CDR error"
@@ -41,30 +66,19 @@ impl std::error::Error for Error {
     }
 
     fn cause(&self) -> Option<&std::error::Error> {
-        match *self.inner.get_context() {
-            ErrorKind::Io(ref err) => Some(err),
+        use Error::*;
+
+        match *self {
+            Io(ref err) => Some(err),
+            InvalidUtf8Encoding(ref err) => Some(err),
             _ => None,
-        }
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner }
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error {
-            inner: Context::new(kind),
         }
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        ErrorKind::Io(err).into()
+        Error::Io(err)
     }
 }
 
@@ -73,7 +87,7 @@ impl serde::de::Error for Error {
     where
         T: fmt::Display,
     {
-        ErrorKind::Message(msg.to_string()).into()
+        Error::Message(msg.to_string())
     }
 }
 
@@ -82,35 +96,6 @@ impl serde::ser::Error for Error {
     where
         T: fmt::Display,
     {
-        ErrorKind::Message(msg.to_string()).into()
+        Error::Message(msg.to_string())
     }
-}
-
-/// The kind of an error.
-#[derive(Debug, Fail)]
-pub enum ErrorKind {
-    #[fail(display = "{}", _0)]
-    Message(String),
-    #[fail(display = "{}", _0)]
-    Io(#[cause] io::Error),
-    #[fail(display = "does not support the serde::Deserializer::deserialize_any method")]
-    DeserializeAnyNotSupported,
-    #[fail(display = "expected 0 or 1, found {}", _0)]
-    InvalidBoolEncoding(u8),
-    #[fail(display = "expected char of width 1, found {}", _0)]
-    InvalidChar(char),
-    #[fail(display = "char is not valid UTF-8")]
-    InvalidCharEncoding,
-    #[fail(display = "encapsulation is not valid")]
-    InvalidEncapsulation,
-    #[fail(display = "string is not valid")]
-    InvalidUtf8Encoding(Utf8Error),
-    #[fail(display = "sequence is too long")]
-    NumberOutOfRange,
-    #[fail(display = "sequences must have a knowable size ahead of time")]
-    SequenceMustHaveLength,
-    #[fail(display = "the size limit has been reached")]
-    SizeLimit,
-    #[fail(display = "unsupported type")]
-    TypeNotSupported,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod encapsulation;
 pub use crate::encapsulation::{CdrBe, CdrLe, Encapsulation, PlCdrBe, PlCdrLe};
 
 mod error;
-pub use crate::error::{Error, ErrorKind, Result};
+pub use crate::error::{Error, Result};
 
 pub mod ser;
 #[doc(inline)]
@@ -66,7 +66,7 @@ where
     use crate::encapsulation::ENCAPSULATION_HEADER_SIZE;
 
     if max < ENCAPSULATION_HEADER_SIZE {
-        Err(ErrorKind::SizeLimit.into())
+        Err(Error::SizeLimit)
     } else {
         size::calc_serialized_data_size_bounded(value, max)
             .map(|size| size + ENCAPSULATION_HEADER_SIZE)
@@ -142,6 +142,6 @@ where
         1 | 3 => serde::Deserialize::deserialize(
             &mut Into::<Deserializer<_, _, LittleEndian>>::into(deserializer),
         ),
-        _ => Err(ErrorKind::InvalidEncapsulation.into()),
+        _ => Err(Error::InvalidEncapsulation),
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -5,7 +5,7 @@ use std::{self, io::Write, marker::PhantomData};
 use byteorder::{ByteOrder, WriteBytesExt};
 use serde::ser;
 
-use crate::error::{Error, ErrorKind, Result};
+use crate::error::{Error, Result};
 use crate::size::{
     calc_serialized_data_size, calc_serialized_data_size_bounded, Infinite, SizeLimit,
 };
@@ -63,7 +63,7 @@ where
 
     fn write_usize_as_u32(&mut self, v: usize) -> Result<()> {
         if v > std::u32::MAX as usize {
-            return Err(ErrorKind::NumberOutOfRange.into());
+            return Err(Error::NumberOutOfRange);
         }
 
         ser::Serializer::serialize_u32(self, v as u32)
@@ -145,7 +145,7 @@ where
     fn serialize_char(self, v: char) -> Result<Self::Ok> {
         let width = v.len_utf8();
         if width != 1 {
-            Err(ErrorKind::InvalidChar(v).into())
+            Err(Error::InvalidChar(v))
         } else {
             let mut buf = [0u8; 1];
             v.encode_utf8(&mut buf);
@@ -171,14 +171,14 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        Err(ErrorKind::TypeNotSupported.into())
+        Err(Error::TypeNotSupported)
     }
 
     fn serialize_some<T: ?Sized>(self, _v: &T) -> Result<Self::Ok>
     where
         T: ser::Serialize,
     {
-        Err(ErrorKind::TypeNotSupported.into())
+        Err(Error::TypeNotSupported)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
@@ -220,7 +220,7 @@ where
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
+        let len = len.ok_or(Error::SequenceMustHaveLength)?;
         self.write_usize_as_u32(len)?;
         Ok(Compound { ser: self })
     }
@@ -249,7 +249,7 @@ where
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        Err(ErrorKind::TypeNotSupported.into())
+        Err(Error::TypeNotSupported)
     }
 
     fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {

--- a/src/size.rs
+++ b/src/size.rs
@@ -4,7 +4,7 @@ use std;
 
 use serde::ser;
 
-use crate::error::{Error, ErrorKind, Result};
+use crate::error::{Error, Result};
 
 /// Limits on the number of bytes that can be read or written.
 pub trait SizeLimit {
@@ -24,7 +24,7 @@ impl SizeLimit for Bounded {
             self.0 -= n;
             Ok(())
         } else {
-            Err(ErrorKind::SizeLimit.into())
+            Err(Error::SizeLimit)
         }
     }
 
@@ -60,7 +60,7 @@ impl SizeLimit for Counter {
         self.total += n;
         if let Some(limit) = self.limit {
             if self.total > limit {
-                return Err(ErrorKind::SizeLimit.into());
+                return Err(Error::SizeLimit);
             }
         }
         Ok(())
@@ -104,7 +104,7 @@ where
 
     fn add_usize_as_u32(&mut self, v: usize) -> Result<()> {
         if v > std::u32::MAX as usize {
-            return Err(ErrorKind::NumberOutOfRange.into());
+            return Err(Error::NumberOutOfRange);
         }
 
         ser::Serializer::serialize_u32(self, v as u32)
@@ -239,7 +239,7 @@ where
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
+        let len = len.ok_or(Error::SequenceMustHaveLength)?;
         self.add_usize_as_u32(len)?;
         Ok(SizeCompound { ser: self })
     }
@@ -268,7 +268,7 @@ where
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        Err(ErrorKind::TypeNotSupported.into())
+        Err(Error::TypeNotSupported)
     }
 
     fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, io::Cursor};
 
 use cdr::{
-    BigEndian, Bounded, CdrBe, CdrLe, ErrorKind, Infinite, LittleEndian, PlCdrBe, PlCdrLe, Result,
+    BigEndian, Bounded, CdrBe, CdrLe, Error, Infinite, LittleEndian, PlCdrBe, PlCdrLe, Result,
 };
 use serde_derive::{Deserialize, Serialize};
 
@@ -786,8 +786,8 @@ fn test_unsupported() {
 
     fn check_error_kind<T: Debug>(res: Result<T>) {
         match res {
-            Err(e) => match e.kind_ref() {
-                &ErrorKind::TypeNotSupported => (),
+            Err(e) => match e {
+                Error::TypeNotSupported => (),
                 e => panic!("unexpected error kind: {}", e),
             },
             _ => panic!("should be error"),


### PR DESCRIPTION
As in [the comment](https://github.com/hrektts/cdr-rs/pull/4#issuecomment-453752371), I found that a simple enum based error type improves the performance of the library.