### PR TITLE
Implement serialization of HashMap

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -172,9 +172,9 @@ where
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok> {
-        let l = v.len();
-        self.write_usize_as_u32(l)?;
-        self.add_pos(l as u64);
+        // let l = v.len();
+        // self.write_usize_as_u32(l)?;
+        // self.add_pos(l as u64);
         self.writer.write_all(v).map_err(Into::into)
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -49,14 +49,22 @@ where
         // Instead of using the slow modulo operation '%', the faster bit-masking is used
         const PADDING: [u8; 8] = [0; 8];
         let alignment = std::mem::size_of::<T>();
-        let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
-        match (self.pos as usize) & rem_mask {
+       
+        match self.padding_length(self.pos, alignment) {
             0 => Ok(()),
-            n @ 1..=7 => {
-                let amt = alignment - n;
+            amt @ 1..=7 => {
                 self.pos += amt as u64;
                 self.writer.write_all(&PADDING[..amt]).map_err(Into::into)
             }
+            _ => unreachable!(),
+        }
+    }
+
+    fn padding_length(&self, pos: u64, alignment: usize) -> usize {
+        let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
+        match (pos as usize) & rem_mask {
+            0 => 0,
+            n @ 1..=7 => alignment - n,
             _ => unreachable!(),
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -802,14 +802,6 @@ fn test_unsupported() {
         &None::<usize>,
         Infinite,
     ));
-    check_error_kind(cdr::ser::serialize_data::<_, _, BigEndian>(
-        &HashMap::<usize, usize>::new(),
-        Infinite,
-    ));
-    check_error_kind(cdr::ser::serialize_data::<_, _, BigEndian>(
-        &BTreeMap::<usize, usize>::new(),
-        Infinite,
-    ));
 
     check_error_kind(cdr::de::deserialize_data::<Option<usize>, BigEndian>(
         &Vec::new().as_slice(),


### PR DESCRIPTION
This PR contains an implementation for the serialization of HashMap.

The serialization is done using the description of Parameter Lists serialization in the RTPS standard. This means that the key is serialized followed by a length in u16 (including padding bytes), followed by the serialized value.

Tests have been updated to verify the new functionality