### PR TITLE
format doc comments

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,9 +2,8 @@
 
 extern crate test;
 
-use test::Bencher;
-
 use serde_derive::{Deserialize, Serialize};
+use test::Bencher;
 
 // cf. https://polysync.io/download/polysync-safety_and_serialization.pdf
 #[repr(C)]

--- a/src/de.rs
+++ b/src/de.rs
@@ -5,8 +5,10 @@ use std::{self, io::Read, marker::PhantomData};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 use serde::de::{self, IntoDeserializer};
 
-use crate::error::{Error, Result};
-use crate::size::{Infinite, SizeLimit};
+use crate::{
+    error::{Error, Result},
+    size::{Infinite, SizeLimit},
+};
 
 /// A deserializer that reads bytes from a buffer.
 pub struct Deserializer<R, S, E> {
@@ -32,8 +34,9 @@ where
     }
 
     fn read_padding_of<T>(&mut self) -> Result<()> {
-        // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte boundaries
-        // Instead of using the slow modulo operation '%', the faster bit-masking is used
+        // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte
+        // boundaries Instead of using the slow modulo operation '%', the faster
+        // bit-masking is used
         let alignment = std::mem::size_of::<T>();
         let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
         let mut padding: [u8; 8] = [0; 8];
@@ -101,6 +104,22 @@ where
 {
     type Error = Error;
 
+    impl_deserialize_value!(deserialize_i16<i16> = visit_i16(read_i16));
+
+    impl_deserialize_value!(deserialize_i32<i32> = visit_i32(read_i32));
+
+    impl_deserialize_value!(deserialize_i64<i64> = visit_i64(read_i64));
+
+    impl_deserialize_value!(deserialize_u16<u16> = visit_u16(read_u16));
+
+    impl_deserialize_value!(deserialize_u32<u32> = visit_u32(read_u32));
+
+    impl_deserialize_value!(deserialize_u64<u64> = visit_u64(read_u64));
+
+    impl_deserialize_value!(deserialize_f32<f32> = visit_f32(read_f32));
+
+    impl_deserialize_value!(deserialize_f64<f64> = visit_f64(read_f64));
+
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
@@ -128,10 +147,6 @@ where
         visitor.visit_i8(self.reader.read_i8()?)
     }
 
-    impl_deserialize_value!(deserialize_i16<i16> = visit_i16(read_i16));
-    impl_deserialize_value!(deserialize_i32<i32> = visit_i32(read_i32));
-    impl_deserialize_value!(deserialize_i64<i64> = visit_i64(read_i64));
-
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
@@ -139,13 +154,6 @@ where
         self.read_size_of::<u8>()?;
         visitor.visit_u8(self.reader.read_u8()?)
     }
-
-    impl_deserialize_value!(deserialize_u16<u16> = visit_u16(read_u16));
-    impl_deserialize_value!(deserialize_u32<u32> = visit_u32(read_u32));
-    impl_deserialize_value!(deserialize_u64<u64> = visit_u64(read_u64));
-
-    impl_deserialize_value!(deserialize_f32<f32> = visit_f32(read_f32));
-    impl_deserialize_value!(deserialize_f64<f64> = visit_f64(read_f64));
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! A serialization/deserialization implementation for Common Data Representation.
+//! A serialization/deserialization implementation for Common Data
+//! Representation.
 //!
 //! # Examples
 //!
@@ -15,15 +16,16 @@
 //! #[derive(Deserialize, Serialize, PartialEq)]
 //! struct Polygon(Vec<Point>);
 //!
-//!     let triangle = Polygon(vec![Point { x: -1.0, y: -1.0 },
-//!                                 Point { x: 1.0, y: -1.0 },
-//!                                 Point { x: 0.0, y: 0.73 }]);
+//! let triangle = Polygon(vec![
+//!     Point { x: -1.0, y: -1.0 },
+//!     Point { x: 1.0, y: -1.0 },
+//!     Point { x: 0.0, y: 0.73 },
+//! ]);
 //!
-//!     let encoded = cdr::serialize::<_, _, CdrBe>(&triangle, Infinite).unwrap();
-//!     let decoded = cdr::deserialize::<Polygon>(&encoded[..]).unwrap();
+//! let encoded = cdr::serialize::<_, _, CdrBe>(&triangle, Infinite).unwrap();
+//! let decoded = cdr::deserialize::<Polygon>(&encoded[..]).unwrap();
 //!
-//!     assert!(triangle == decoded);
-
+//! assert!(triangle == decoded);
 //! ```
 
 pub use byteorder::{BigEndian, LittleEndian};
@@ -43,10 +45,10 @@ pub mod ser;
 pub use crate::ser::Serializer;
 
 pub mod size;
+use std::io::{Read, Write};
+
 #[doc(inline)]
 pub use crate::size::{Bounded, Infinite, SizeLimit};
-
-use std::io::{Read, Write};
 
 /// Returns the size that an object would be if serialized with a encapsulation.
 pub fn calc_serialized_size<T>(value: &T) -> u64
@@ -72,7 +74,8 @@ where
     }
 }
 
-/// Serializes a serializable object into a `Vec` of bytes with the encapsulation.
+/// Serializes a serializable object into a `Vec` of bytes with the
+/// encapsulation.
 pub fn serialize<T, S, C>(value: &T, size_limit: S) -> Result<Vec<u8>>
 where
     T: serde::Serialize + ?Sized,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -5,9 +5,9 @@ use std::{self, io::Write, marker::PhantomData};
 use byteorder::{ByteOrder, WriteBytesExt};
 use serde::ser;
 
-use crate::error::{Error, Result};
-use crate::size::{
-    calc_serialized_data_size, calc_serialized_data_size_bounded, Infinite, SizeLimit,
+use crate::{
+    error::{Error, Result},
+    size::{calc_serialized_data_size, calc_serialized_data_size_bounded, Infinite, SizeLimit},
 };
 
 /// A serializer that writes values into a buffer.
@@ -45,8 +45,9 @@ where
     }
 
     fn write_padding_of<T>(&mut self) -> Result<()> {
-        // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte boundaries
-        // Instead of using the slow modulo operation '%', the faster bit-masking is used
+        // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte
+        // boundaries Instead of using the slow modulo operation '%', the faster
+        // bit-masking is used
         const PADDING: [u8; 8] = [0; 8];
         let alignment = std::mem::size_of::<T>();
         let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
@@ -84,15 +85,31 @@ where
     W: Write,
     E: ByteOrder,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
+    type SerializeMap = Compound<'a, W, E>;
     type SerializeSeq = Compound<'a, W, E>;
+    type SerializeStruct = Compound<'a, W, E>;
+    type SerializeStructVariant = Compound<'a, W, E>;
     type SerializeTuple = Compound<'a, W, E>;
     type SerializeTupleStruct = Compound<'a, W, E>;
     type SerializeTupleVariant = Compound<'a, W, E>;
-    type SerializeMap = Compound<'a, W, E>;
-    type SerializeStruct = Compound<'a, W, E>;
-    type SerializeStructVariant = Compound<'a, W, E>;
+
+    impl_serialize_value! { serialize_i16(i16) = write_i16() }
+
+    impl_serialize_value! { serialize_i32(i32) = write_i32() }
+
+    impl_serialize_value! { serialize_i64(i64) = write_i64() }
+
+    impl_serialize_value! { serialize_u16(u16) = write_u16() }
+
+    impl_serialize_value! { serialize_u32(u32) = write_u32() }
+
+    impl_serialize_value! { serialize_u64(u64) = write_u64() }
+
+    impl_serialize_value! { serialize_f32(f32) = write_f32() }
+
+    impl_serialize_value! { serialize_f64(f64) = write_f64() }
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
         self.set_pos_of::<bool>()?;
@@ -104,21 +121,10 @@ where
         self.writer.write_i8(v).map_err(Into::into)
     }
 
-    impl_serialize_value! { serialize_i16(i16) = write_i16() }
-    impl_serialize_value! { serialize_i32(i32) = write_i32() }
-    impl_serialize_value! { serialize_i64(i64) = write_i64() }
-
     fn serialize_u8(self, v: u8) -> Result<Self::Ok> {
         self.set_pos_of::<u8>()?;
         self.writer.write_u8(v).map_err(Into::into)
     }
-
-    impl_serialize_value! { serialize_u16(u16) = write_u16() }
-    impl_serialize_value! { serialize_u32(u32) = write_u32() }
-    impl_serialize_value! { serialize_u64(u64) = write_u64() }
-
-    impl_serialize_value! { serialize_f32(f32) = write_f32() }
-    impl_serialize_value! { serialize_f64(f64) = write_f64() }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok> {
         if !v.is_ascii() {
@@ -263,8 +269,8 @@ where
     W: Write,
     E: ByteOrder,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
@@ -285,8 +291,8 @@ where
     W: Write,
     E: ByteOrder,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
@@ -307,8 +313,8 @@ where
     W: Write,
     E: ByteOrder,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
@@ -329,8 +335,8 @@ where
     W: Write,
     E: ByteOrder,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
@@ -351,8 +357,8 @@ where
     W: Write,
     E: ByteOrder,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_key<T>(&mut self, key: &T) -> Result<()>
@@ -381,8 +387,8 @@ where
     W: Write,
     E: ByteOrder,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
@@ -403,8 +409,8 @@ where
     W: Write,
     E: ByteOrder,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
@@ -460,8 +466,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use byteorder::{BigEndian, LittleEndian};
+
+    use super::*;
 
     #[test]
     fn serialize_octet() {

--- a/src/size.rs
+++ b/src/size.rs
@@ -122,32 +122,39 @@ impl<'a, S> ser::Serializer for &'a mut SizeChecker<S>
 where
     S: SizeLimit,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
+    type SerializeMap = SizeCompound<'a, S>;
     type SerializeSeq = SizeCompound<'a, S>;
+    type SerializeStruct = SizeCompound<'a, S>;
+    type SerializeStructVariant = SizeCompound<'a, S>;
     type SerializeTuple = SizeCompound<'a, S>;
     type SerializeTupleStruct = SizeCompound<'a, S>;
     type SerializeTupleVariant = SizeCompound<'a, S>;
-    type SerializeMap = SizeCompound<'a, S>;
-    type SerializeStruct = SizeCompound<'a, S>;
-    type SerializeStructVariant = SizeCompound<'a, S>;
+
+    impl_serialize_value! { serialize_i8(i8) }
+
+    impl_serialize_value! { serialize_i16(i16) }
+
+    impl_serialize_value! { serialize_i32(i32) }
+
+    impl_serialize_value! { serialize_i64(i64) }
+
+    impl_serialize_value! { serialize_u8(u8) }
+
+    impl_serialize_value! { serialize_u16(u16) }
+
+    impl_serialize_value! { serialize_u32(u32) }
+
+    impl_serialize_value! { serialize_u64(u64) }
+
+    impl_serialize_value! { serialize_f32(f32) }
+
+    impl_serialize_value! { serialize_f64(f64) }
 
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok> {
         self.add_value(0u8)
     }
-
-    impl_serialize_value! { serialize_i8(i8) }
-    impl_serialize_value! { serialize_i16(i16) }
-    impl_serialize_value! { serialize_i32(i32) }
-    impl_serialize_value! { serialize_i64(i64) }
-
-    impl_serialize_value! { serialize_u8(u8) }
-    impl_serialize_value! { serialize_u16(u16) }
-    impl_serialize_value! { serialize_u32(u32) }
-    impl_serialize_value! { serialize_u64(u64) }
-
-    impl_serialize_value! { serialize_f32(f32) }
-    impl_serialize_value! { serialize_f64(f64) }
 
     fn serialize_char(self, _v: char) -> Result<Self::Ok> {
         self.add_size(1)
@@ -274,8 +281,8 @@ impl<'a, S> ser::SerializeSeq for SizeCompound<'a, S>
 where
     S: SizeLimit,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
@@ -295,8 +302,8 @@ impl<'a, S> ser::SerializeTuple for SizeCompound<'a, S>
 where
     S: SizeLimit,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
@@ -316,8 +323,8 @@ impl<'a, S> ser::SerializeTupleStruct for SizeCompound<'a, S>
 where
     S: SizeLimit,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
@@ -337,8 +344,8 @@ impl<'a, S> ser::SerializeTupleVariant for SizeCompound<'a, S>
 where
     S: SizeLimit,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
@@ -358,8 +365,8 @@ impl<'a, S> ser::SerializeMap for SizeCompound<'a, S>
 where
     S: SizeLimit,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_key<T>(&mut self, key: &T) -> Result<()>
@@ -387,8 +394,8 @@ impl<'a, S> ser::SerializeStruct for SizeCompound<'a, S>
 where
     S: SizeLimit,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
@@ -408,8 +415,8 @@ impl<'a, S> ser::SerializeStructVariant for SizeCompound<'a, S>
 where
     S: SizeLimit,
 {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>


### PR DESCRIPTION
this PR uses a slightly more comprehensive rustfmt config to

- reorder impl items to match trait definitions
- normalise and format doc comments
- merge and organise imports