### PR TITLE
add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+name: Code Coverage
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --doctests --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
adds a code coverage workflow to CI

Requires codecov to be set up to allow it to post coverage reports on pull requests. For example- https://github.com/danieleades/monzo-lib/pull/51#issuecomment-1076856632