### PR TITLE
[BREAKING CHANGE] remove 'SizeLimit' trait

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -50,22 +50,22 @@ fn compose_lidar_points_msg() -> LidarPointsMsg {
 
 #[bench]
 fn lidar_point_msg(b: &mut Bencher) {
-    use cdr::{self, CdrBe, Infinite};
+    use cdr::{self, CdrBe};
 
     let msg = compose_lidar_points_msg();
     b.iter(|| {
-        let encoded = cdr::serialize::<_, _, CdrBe>(&msg, Infinite).unwrap();
+        let encoded = cdr::serialize::<_, CdrBe>(&msg, None).unwrap();
         let _decoded = cdr::deserialize::<LidarPointsMsg>(&encoded[..]).unwrap();
     });
 }
 
 #[bench]
 fn lidar_point_msg_without_encapsulation(b: &mut Bencher) {
-    use cdr::{self, BigEndian, Infinite};
+    use cdr::{self, BigEndian};
 
     let msg = compose_lidar_points_msg();
     b.iter(|| {
-        let encoded = cdr::ser::serialize_data::<_, _, BigEndian>(&msg, Infinite).unwrap();
+        let encoded = cdr::ser::serialize_data::<_, BigEndian>(&msg, None).unwrap();
         let _decoded =
             cdr::de::deserialize_data::<LidarPointsMsg, BigEndian>(&encoded[..]).unwrap();
     });
@@ -137,22 +137,22 @@ That fought with us upon Saint Crispin's day.
 
 #[bench]
 fn string_msg(b: &mut Bencher) {
-    use cdr::{self, CdrBe, Infinite};
+    use cdr::{self, CdrBe};
 
     let msg = compose_string_msg();
     b.iter(|| {
-        let encoded = cdr::serialize::<_, _, CdrBe>(&msg, Infinite).unwrap();
+        let encoded = cdr::serialize::<_, CdrBe>(&msg, None).unwrap();
         let _decoded = cdr::deserialize::<String>(&encoded[..]).unwrap();
     });
 }
 
 #[bench]
 fn string_msg_without_encapsulation(b: &mut Bencher) {
-    use cdr::{self, BigEndian, Infinite};
+    use cdr::{self, BigEndian};
 
     let msg = compose_string_msg();
     b.iter(|| {
-        let encoded = cdr::ser::serialize_data::<_, _, BigEndian>(&msg, Infinite).unwrap();
+        let encoded = cdr::ser::serialize_data::<_, BigEndian>(&msg, None).unwrap();
         let _decoded = cdr::de::deserialize_data::<String, BigEndian>(&encoded[..]).unwrap();
     });
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,9 +2,8 @@
 
 extern crate test;
 
-use test::Bencher;
-
 use serde_derive::{Deserialize, Serialize};
+use test::Bencher;
 
 // cf. https://polysync.io/download/polysync-safety_and_serialization.pdf
 #[repr(C)]

--- a/src/de.rs
+++ b/src/de.rs
@@ -32,8 +32,9 @@ where
     }
 
     fn read_padding_of<T>(&mut self) -> Result<()> {
-        // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte boundaries
-        // Instead of using the slow modulo operation '%', the faster bit-masking is used
+        // Calculate the required padding to align with 1-byte, 2-byte, 4-byte, 8-byte
+        // boundaries Instead of using the slow modulo operation '%', the faster
+        // bit-masking is used
         let alignment = std::mem::size_of::<T>();
         let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
         let mut padding: [u8; 8] = [0; 8];
@@ -108,6 +109,22 @@ where
 {
     type Error = Error;
 
+    impl_deserialize_value!(deserialize_i16<i16> = visit_i16(read_i16));
+
+    impl_deserialize_value!(deserialize_i32<i32> = visit_i32(read_i32));
+
+    impl_deserialize_value!(deserialize_i64<i64> = visit_i64(read_i64));
+
+    impl_deserialize_value!(deserialize_u16<u16> = visit_u16(read_u16));
+
+    impl_deserialize_value!(deserialize_u32<u32> = visit_u32(read_u32));
+
+    impl_deserialize_value!(deserialize_u64<u64> = visit_u64(read_u64));
+
+    impl_deserialize_value!(deserialize_f32<f32> = visit_f32(read_f32));
+
+    impl_deserialize_value!(deserialize_f64<f64> = visit_f64(read_f64));
+
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
@@ -135,10 +152,6 @@ where
         visitor.visit_i8(self.reader.read_i8()?)
     }
 
-    impl_deserialize_value!(deserialize_i16<i16> = visit_i16(read_i16));
-    impl_deserialize_value!(deserialize_i32<i32> = visit_i32(read_i32));
-    impl_deserialize_value!(deserialize_i64<i64> = visit_i64(read_i64));
-
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
@@ -146,13 +159,6 @@ where
         self.read_size_of::<u8>()?;
         visitor.visit_u8(self.reader.read_u8()?)
     }
-
-    impl_deserialize_value!(deserialize_u16<u16> = visit_u16(read_u16));
-    impl_deserialize_value!(deserialize_u32<u32> = visit_u32(read_u32));
-    impl_deserialize_value!(deserialize_u64<u64> = visit_u64(read_u64));
-
-    impl_deserialize_value!(deserialize_f32<f32> = visit_f32(read_f32));
-    impl_deserialize_value!(deserialize_f64<f64> = visit_f64(read_f64));
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! A serialization/deserialization implementation for Common Data Representation.
+//! A serialization/deserialization implementation for Common Data
+//! Representation.
 //!
 //! # Examples
 //!
@@ -70,7 +71,8 @@ where
     }
 }
 
-/// Serializes a serializable object into a `Vec` of bytes with the encapsulation.
+/// Serializes a serializable object into a `Vec` of bytes with the
+/// encapsulation.
 pub fn serialize<T, C>(value: &T, size_limit: Option<u64>) -> Result<Vec<u8>>
 where
     T: serde::Serialize + ?Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,6 @@ pub mod ser;
 pub use crate::ser::Serializer;
 
 pub mod size;
-#[doc(inline)]
-pub use crate::size::{Bounded, Infinite, SizeLimit};
 
 use std::io::{Read, Write};
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -18,6 +18,7 @@ impl SizeChecker {
             pos: 0,
         }
     }
+
     fn add_padding_of<T>(&mut self) -> Result<()> {
         let alignment = std::mem::size_of::<T>();
         let rem_mask = alignment - 1; // mask like 0x0, 0x1, 0x3, 0x7
@@ -67,32 +68,39 @@ macro_rules! impl_serialize_value {
 }
 
 impl<'a> ser::Serializer for &'a mut SizeChecker {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
+    type SerializeMap = SizeCompound<'a>;
     type SerializeSeq = SizeCompound<'a>;
+    type SerializeStruct = SizeCompound<'a>;
+    type SerializeStructVariant = SizeCompound<'a>;
     type SerializeTuple = SizeCompound<'a>;
     type SerializeTupleStruct = SizeCompound<'a>;
     type SerializeTupleVariant = SizeCompound<'a>;
-    type SerializeMap = SizeCompound<'a>;
-    type SerializeStruct = SizeCompound<'a>;
-    type SerializeStructVariant = SizeCompound<'a>;
+
+    impl_serialize_value! { serialize_i8(i8) }
+
+    impl_serialize_value! { serialize_i16(i16) }
+
+    impl_serialize_value! { serialize_i32(i32) }
+
+    impl_serialize_value! { serialize_i64(i64) }
+
+    impl_serialize_value! { serialize_u8(u8) }
+
+    impl_serialize_value! { serialize_u16(u16) }
+
+    impl_serialize_value! { serialize_u32(u32) }
+
+    impl_serialize_value! { serialize_u64(u64) }
+
+    impl_serialize_value! { serialize_f32(f32) }
+
+    impl_serialize_value! { serialize_f64(f64) }
 
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok> {
         self.add_value(0u8)
     }
-
-    impl_serialize_value! { serialize_i8(i8) }
-    impl_serialize_value! { serialize_i16(i16) }
-    impl_serialize_value! { serialize_i32(i32) }
-    impl_serialize_value! { serialize_i64(i64) }
-
-    impl_serialize_value! { serialize_u8(u8) }
-    impl_serialize_value! { serialize_u16(u16) }
-    impl_serialize_value! { serialize_u32(u32) }
-    impl_serialize_value! { serialize_u64(u64) }
-
-    impl_serialize_value! { serialize_f32(f32) }
-    impl_serialize_value! { serialize_f64(f64) }
 
     fn serialize_char(self, _v: char) -> Result<Self::Ok> {
         self.add_size(1)
@@ -216,8 +224,8 @@ pub struct SizeCompound<'a> {
 }
 
 impl<'a> ser::SerializeSeq for SizeCompound<'a> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
@@ -234,8 +242,8 @@ impl<'a> ser::SerializeSeq for SizeCompound<'a> {
 }
 
 impl<'a> ser::SerializeTuple for SizeCompound<'a> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
@@ -252,8 +260,8 @@ impl<'a> ser::SerializeTuple for SizeCompound<'a> {
 }
 
 impl<'a> ser::SerializeTupleStruct for SizeCompound<'a> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
@@ -270,8 +278,8 @@ impl<'a> ser::SerializeTupleStruct for SizeCompound<'a> {
 }
 
 impl<'a> ser::SerializeTupleVariant for SizeCompound<'a> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
@@ -288,8 +296,8 @@ impl<'a> ser::SerializeTupleVariant for SizeCompound<'a> {
 }
 
 impl<'a> ser::SerializeMap for SizeCompound<'a> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_key<T>(&mut self, key: &T) -> Result<()>
@@ -314,8 +322,8 @@ impl<'a> ser::SerializeMap for SizeCompound<'a> {
 }
 
 impl<'a> ser::SerializeStruct for SizeCompound<'a> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
@@ -332,8 +340,8 @@ impl<'a> ser::SerializeStruct for SizeCompound<'a> {
 }
 
 impl<'a> ser::SerializeStructVariant for SizeCompound<'a> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     #[inline]
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -175,10 +175,11 @@ where
         {
             let encoded = cdr::ser::serialize_data::<_, LittleEndian>(&element, None).unwrap();
             let mut encoded = encoded.as_slice();
-            assert!(
-                cdr::de::deserialize_data_from::<_, T, LittleEndian>(&mut encoded, Some(bound))
-                    .is_err()
-            );
+            assert!(cdr::de::deserialize_data_from::<_, T, LittleEndian>(
+                &mut encoded,
+                Some(bound)
+            )
+            .is_err());
         }
         {
             let encoded = cdr::serialize::<_, CdrBe>(&element, None).unwrap();
@@ -270,7 +271,11 @@ where
         Some(_) => None,
         None => {
             let size = cdr::size::calc_serialized_data_size(&element);
-            if size > 0 { Some(size - 1) } else { None }
+            if size > 0 {
+                Some(size - 1)
+            } else {
+                None
+            }
         }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -173,11 +173,10 @@ where
         {
             let encoded = cdr::ser::serialize_data::<_, LittleEndian>(&element, None).unwrap();
             let mut encoded = encoded.as_slice();
-            assert!(cdr::de::deserialize_data_from::<_, T, LittleEndian>(
-                &mut encoded,
-                Some(bound)
-            )
-            .is_err());
+            assert!(
+                cdr::de::deserialize_data_from::<_, T, LittleEndian>(&mut encoded, Some(bound))
+                    .is_err()
+            );
         }
         {
             let encoded = cdr::serialize::<_, CdrBe>(&element, None).unwrap();
@@ -269,11 +268,7 @@ where
         Some(_) => None,
         None => {
             let size = cdr::size::calc_serialized_data_size(&element);
-            if size > 0 {
-                Some(size - 1)
-            } else {
-                None
-            }
+            if size > 0 { Some(size - 1) } else { None }
         }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,6 @@
 use std::{fmt::Debug, io::Cursor};
 
-use cdr::{
-    BigEndian, Bounded, CdrBe, CdrLe, Error, Infinite, LittleEndian, PlCdrBe, PlCdrLe, Result,
-};
+use cdr::{BigEndian, CdrBe, CdrLe, Error, LittleEndian, PlCdrBe, PlCdrLe, Result};
 use serde_derive::{Deserialize, Serialize};
 
 const ENCAPSULATION_HEADER_SIZE: u64 = 4;
@@ -42,42 +40,42 @@ where
         None => cdr::calc_serialized_size(&element),
     };
     {
-        let encoded = cdr::ser::serialize_data::<_, _, BigEndian>(element, Infinite).unwrap();
+        let encoded = cdr::ser::serialize_data::<_, BigEndian>(element, None).unwrap();
         let decoded = cdr::de::deserialize_data::<T, BigEndian>(&encoded).unwrap();
 
         assert_eq!(*element, decoded);
         assert_eq!(size, encoded.len() as u64);
     }
     {
-        let encoded = cdr::ser::serialize_data::<_, _, LittleEndian>(element, Infinite).unwrap();
+        let encoded = cdr::ser::serialize_data::<_, LittleEndian>(element, None).unwrap();
         let decoded = cdr::de::deserialize_data::<T, LittleEndian>(&encoded).unwrap();
 
         assert_eq!(*element, decoded);
         assert_eq!(size, encoded.len() as u64);
     }
     {
-        let encoded = cdr::serialize::<_, _, CdrBe>(element, Infinite).unwrap();
+        let encoded = cdr::serialize::<_, CdrBe>(element, None).unwrap();
         let decoded = cdr::deserialize(&encoded).unwrap();
 
         assert_eq!(*element, decoded);
         assert_eq!(size + ENCAPSULATION_HEADER_SIZE, encoded.len() as u64);
     }
     {
-        let encoded = cdr::serialize::<_, _, CdrLe>(element, Infinite).unwrap();
+        let encoded = cdr::serialize::<_, CdrLe>(element, None).unwrap();
         let decoded = cdr::deserialize(&encoded).unwrap();
 
         assert_eq!(*element, decoded);
         assert_eq!(size + ENCAPSULATION_HEADER_SIZE, encoded.len() as u64);
     }
     {
-        let encoded = cdr::serialize::<_, _, PlCdrBe>(element, Infinite).unwrap();
+        let encoded = cdr::serialize::<_, PlCdrBe>(element, None).unwrap();
         let decoded = cdr::deserialize(&encoded).unwrap();
 
         assert_eq!(*element, decoded);
         assert_eq!(size + ENCAPSULATION_HEADER_SIZE, encoded.len() as u64);
     }
     {
-        let encoded = cdr::serialize::<_, _, PlCdrLe>(element, Infinite).unwrap();
+        let encoded = cdr::serialize::<_, PlCdrLe>(element, None).unwrap();
         let decoded = cdr::deserialize(&encoded).unwrap();
 
         assert_eq!(*element, decoded);
@@ -93,64 +91,62 @@ where
     if let Some(bound) = calc_invalid_size(element, maybe_size) {
         {
             let mut buf = Cursor::new(&mut buf[0..bound as usize]);
-            assert!(cdr::ser::serialize_data_into::<_, _, _, BigEndian>(
-                &mut buf, &element, Infinite
-            )
-            .is_err());
+            assert!(
+                cdr::ser::serialize_data_into::<_, _, BigEndian>(&mut buf, &element, None).is_err()
+            );
         }
         {
             let mut buf = Cursor::new(&mut buf[0..bound as usize]);
-            assert!(cdr::ser::serialize_data_into::<_, _, _, LittleEndian>(
-                &mut buf, &element, Infinite
-            )
-            .is_err());
+            assert!(
+                cdr::ser::serialize_data_into::<_, _, LittleEndian>(&mut buf, &element, None)
+                    .is_err()
+            );
         }
         {
             let mut buf = Cursor::new(&mut buf[0..bound as usize]);
-            assert!(cdr::serialize_into::<_, _, _, CdrBe>(&mut buf, &element, Infinite).is_err());
+            assert!(cdr::serialize_into::<_, _, CdrBe>(&mut buf, &element, None).is_err());
         }
         {
             let mut buf = Cursor::new(&mut buf[0..bound as usize]);
-            assert!(cdr::serialize_into::<_, _, _, CdrLe>(&mut buf, &element, Infinite).is_err());
+            assert!(cdr::serialize_into::<_, _, CdrLe>(&mut buf, &element, None).is_err());
         }
         {
             let mut buf = Cursor::new(&mut buf[0..bound as usize]);
-            assert!(cdr::serialize_into::<_, _, _, PlCdrBe>(&mut buf, &element, Infinite).is_err());
+            assert!(cdr::serialize_into::<_, _, PlCdrBe>(&mut buf, &element, None).is_err());
         }
         {
             let mut buf = Cursor::new(&mut buf[0..bound as usize]);
-            assert!(cdr::serialize_into::<_, _, _, PlCdrLe>(&mut buf, &element, Infinite).is_err());
+            assert!(cdr::serialize_into::<_, _, PlCdrLe>(&mut buf, &element, None).is_err());
         }
     } else {
         {
             let mut buf = Cursor::new(&mut buf[0..0]);
-            assert!(cdr::ser::serialize_data_into::<_, _, _, BigEndian>(
-                &mut buf, &element, Infinite
-            )
-            .is_ok());
+            assert!(
+                cdr::ser::serialize_data_into::<_, _, BigEndian>(&mut buf, &element, None).is_ok()
+            );
         }
         {
             let mut buf = Cursor::new(&mut buf[0..0]);
-            assert!(cdr::ser::serialize_data_into::<_, _, _, LittleEndian>(
-                &mut buf, &element, Infinite
-            )
-            .is_ok());
+            assert!(
+                cdr::ser::serialize_data_into::<_, _, LittleEndian>(&mut buf, &element, None)
+                    .is_ok()
+            );
         }
         {
             let mut buf = Cursor::new(&mut buf[0..ENCAPSULATION_HEADER_SIZE as usize]);
-            assert!(cdr::serialize_into::<_, _, _, CdrBe>(&mut buf, &element, Infinite).is_ok());
+            assert!(cdr::serialize_into::<_, _, CdrBe>(&mut buf, &element, None).is_ok());
         }
         {
             let mut buf = Cursor::new(&mut buf[0..ENCAPSULATION_HEADER_SIZE as usize]);
-            assert!(cdr::serialize_into::<_, _, _, CdrLe>(&mut buf, &element, Infinite).is_ok());
+            assert!(cdr::serialize_into::<_, _, CdrLe>(&mut buf, &element, None).is_ok());
         }
         {
             let mut buf = Cursor::new(&mut buf[0..ENCAPSULATION_HEADER_SIZE as usize]);
-            assert!(cdr::serialize_into::<_, _, _, PlCdrBe>(&mut buf, &element, Infinite).is_ok());
+            assert!(cdr::serialize_into::<_, _, PlCdrBe>(&mut buf, &element, None).is_ok());
         }
         {
             let mut buf = Cursor::new(&mut buf[0..ENCAPSULATION_HEADER_SIZE as usize]);
-            assert!(cdr::serialize_into::<_, _, _, PlCdrLe>(&mut buf, &element, Infinite).is_ok());
+            assert!(cdr::serialize_into::<_, _, PlCdrLe>(&mut buf, &element, None).is_ok());
         }
     }
 }
@@ -160,112 +156,103 @@ where
     T: serde::Serialize + serde::Deserialize<'de> + PartialEq + Debug,
 {
     if let Some(bound) = calc_invalid_size(element, maybe_size) {
-        assert!(cdr::ser::serialize_data::<_, _, BigEndian>(&element, Bounded(bound)).is_err());
-        assert!(cdr::ser::serialize_data::<_, _, LittleEndian>(&element, Bounded(bound)).is_err());
-        assert!(cdr::serialize::<_, _, CdrBe>(&element, Bounded(bound)).is_err());
-        assert!(cdr::serialize::<_, _, CdrLe>(&element, Bounded(bound)).is_err());
-        assert!(cdr::serialize::<_, _, PlCdrBe>(&element, Bounded(bound)).is_err());
-        assert!(cdr::serialize::<_, _, PlCdrLe>(&element, Bounded(bound)).is_err());
+        assert!(cdr::ser::serialize_data::<_, BigEndian>(&element, Some(bound)).is_err());
+        assert!(cdr::ser::serialize_data::<_, LittleEndian>(&element, Some(bound)).is_err());
+        assert!(cdr::serialize::<_, CdrBe>(&element, Some(bound)).is_err());
+        assert!(cdr::serialize::<_, CdrLe>(&element, Some(bound)).is_err());
+        assert!(cdr::serialize::<_, PlCdrBe>(&element, Some(bound)).is_err());
+        assert!(cdr::serialize::<_, PlCdrLe>(&element, Some(bound)).is_err());
         {
-            let encoded = cdr::ser::serialize_data::<_, _, BigEndian>(&element, Infinite).unwrap();
+            let encoded = cdr::ser::serialize_data::<_, BigEndian>(&element, None).unwrap();
             let mut encoded = encoded.as_slice();
-            assert!(cdr::de::deserialize_data_from::<_, T, _, BigEndian>(
+            assert!(
+                cdr::de::deserialize_data_from::<_, T, BigEndian>(&mut encoded, Some(bound))
+                    .is_err()
+            );
+        }
+        {
+            let encoded = cdr::ser::serialize_data::<_, LittleEndian>(&element, None).unwrap();
+            let mut encoded = encoded.as_slice();
+            assert!(cdr::de::deserialize_data_from::<_, T, LittleEndian>(
                 &mut encoded,
-                Bounded(bound)
+                Some(bound)
             )
             .is_err());
         }
         {
-            let encoded =
-                cdr::ser::serialize_data::<_, _, LittleEndian>(&element, Infinite).unwrap();
+            let encoded = cdr::serialize::<_, CdrBe>(&element, None).unwrap();
             let mut encoded = encoded.as_slice();
-            assert!(cdr::de::deserialize_data_from::<_, T, _, LittleEndian>(
-                &mut encoded,
-                Bounded(bound)
-            )
-            .is_err());
+            assert!(cdr::deserialize_from::<_, T>(&mut encoded, Some(bound)).is_err());
         }
         {
-            let encoded = cdr::serialize::<_, _, CdrBe>(&element, Infinite).unwrap();
+            let encoded = cdr::serialize::<_, CdrLe>(&element, None).unwrap();
             let mut encoded = encoded.as_slice();
-            assert!(cdr::deserialize_from::<_, T, _>(&mut encoded, Bounded(bound)).is_err());
+            assert!(cdr::deserialize_from::<_, T>(&mut encoded, Some(bound)).is_err());
         }
         {
-            let encoded = cdr::serialize::<_, _, CdrLe>(&element, Infinite).unwrap();
+            let encoded = cdr::serialize::<_, PlCdrBe>(&element, None).unwrap();
             let mut encoded = encoded.as_slice();
-            assert!(cdr::deserialize_from::<_, T, _>(&mut encoded, Bounded(bound)).is_err());
+            assert!(cdr::deserialize_from::<_, T>(&mut encoded, Some(bound)).is_err());
         }
         {
-            let encoded = cdr::serialize::<_, _, PlCdrBe>(&element, Infinite).unwrap();
+            let encoded = cdr::serialize::<_, PlCdrLe>(&element, None).unwrap();
             let mut encoded = encoded.as_slice();
-            assert!(cdr::deserialize_from::<_, T, _>(&mut encoded, Bounded(bound)).is_err());
-        }
-        {
-            let encoded = cdr::serialize::<_, _, PlCdrLe>(&element, Infinite).unwrap();
-            let mut encoded = encoded.as_slice();
-            assert!(cdr::deserialize_from::<_, T, _>(&mut encoded, Bounded(bound)).is_err());
+            assert!(cdr::deserialize_from::<_, T>(&mut encoded, Some(bound)).is_err());
         }
     } else {
         {
-            let encoded =
-                cdr::ser::serialize_data::<_, _, BigEndian>(&element, Bounded(0)).unwrap();
+            let encoded = cdr::ser::serialize_data::<_, BigEndian>(&element, Some(0)).unwrap();
             let mut encoded = encoded.as_slice();
             let decoded =
-                cdr::de::deserialize_data_from::<_, T, _, BigEndian>(&mut encoded, Bounded(0))
+                cdr::de::deserialize_data_from::<_, T, BigEndian>(&mut encoded, Some(0)).unwrap();
+
+            assert_eq!(*element, decoded);
+        }
+        {
+            let encoded = cdr::ser::serialize_data::<_, LittleEndian>(&element, Some(0)).unwrap();
+            let mut encoded = encoded.as_slice();
+            let decoded =
+                cdr::de::deserialize_data_from::<_, T, LittleEndian>(&mut encoded, Some(0))
                     .unwrap();
 
             assert_eq!(*element, decoded);
         }
         {
             let encoded =
-                cdr::ser::serialize_data::<_, _, LittleEndian>(&element, Bounded(0)).unwrap();
+                cdr::serialize::<_, CdrBe>(&element, Some(ENCAPSULATION_HEADER_SIZE)).unwrap();
             let mut encoded = encoded.as_slice();
             let decoded =
-                cdr::de::deserialize_data_from::<_, T, _, LittleEndian>(&mut encoded, Bounded(0))
+                cdr::deserialize_from::<_, T>(&mut encoded, Some(ENCAPSULATION_HEADER_SIZE))
                     .unwrap();
 
             assert_eq!(*element, decoded);
         }
         {
             let encoded =
-                cdr::serialize::<_, _, CdrBe>(&element, Bounded(ENCAPSULATION_HEADER_SIZE))
-                    .unwrap();
+                cdr::serialize::<_, CdrLe>(&element, Some(ENCAPSULATION_HEADER_SIZE)).unwrap();
             let mut encoded = encoded.as_slice();
             let decoded =
-                cdr::deserialize_from::<_, T, _>(&mut encoded, Bounded(ENCAPSULATION_HEADER_SIZE))
+                cdr::deserialize_from::<_, T>(&mut encoded, Some(ENCAPSULATION_HEADER_SIZE))
                     .unwrap();
 
             assert_eq!(*element, decoded);
         }
         {
             let encoded =
-                cdr::serialize::<_, _, CdrLe>(&element, Bounded(ENCAPSULATION_HEADER_SIZE))
-                    .unwrap();
+                cdr::serialize::<_, PlCdrBe>(&element, Some(ENCAPSULATION_HEADER_SIZE)).unwrap();
             let mut encoded = encoded.as_slice();
             let decoded =
-                cdr::deserialize_from::<_, T, _>(&mut encoded, Bounded(ENCAPSULATION_HEADER_SIZE))
+                cdr::deserialize_from::<_, T>(&mut encoded, Some(ENCAPSULATION_HEADER_SIZE))
                     .unwrap();
 
             assert_eq!(*element, decoded);
         }
         {
             let encoded =
-                cdr::serialize::<_, _, PlCdrBe>(&element, Bounded(ENCAPSULATION_HEADER_SIZE))
-                    .unwrap();
+                cdr::serialize::<_, PlCdrLe>(&element, Some(ENCAPSULATION_HEADER_SIZE)).unwrap();
             let mut encoded = encoded.as_slice();
             let decoded =
-                cdr::deserialize_from::<_, T, _>(&mut encoded, Bounded(ENCAPSULATION_HEADER_SIZE))
-                    .unwrap();
-
-            assert_eq!(*element, decoded);
-        }
-        {
-            let encoded =
-                cdr::serialize::<_, _, PlCdrLe>(&element, Bounded(ENCAPSULATION_HEADER_SIZE))
-                    .unwrap();
-            let mut encoded = encoded.as_slice();
-            let decoded =
-                cdr::deserialize_from::<_, T, _>(&mut encoded, Bounded(ENCAPSULATION_HEADER_SIZE))
+                cdr::deserialize_from::<_, T>(&mut encoded, Some(ENCAPSULATION_HEADER_SIZE))
                     .unwrap();
 
             assert_eq!(*element, decoded);
@@ -782,21 +769,21 @@ fn test_unsupported() {
         }
     }
 
-    check_error_kind(cdr::ser::serialize_data::<_, _, BigEndian>(
+    check_error_kind(cdr::ser::serialize_data::<_, BigEndian>(
         &Some(1usize),
-        Infinite,
+        None,
     ));
-    check_error_kind(cdr::ser::serialize_data::<_, _, BigEndian>(
+    check_error_kind(cdr::ser::serialize_data::<_, BigEndian>(
         &None::<usize>,
-        Infinite,
+        None,
     ));
-    check_error_kind(cdr::ser::serialize_data::<_, _, BigEndian>(
+    check_error_kind(cdr::ser::serialize_data::<_, BigEndian>(
         &HashMap::<usize, usize>::new(),
-        Infinite,
+        None,
     ));
-    check_error_kind(cdr::ser::serialize_data::<_, _, BigEndian>(
+    check_error_kind(cdr::ser::serialize_data::<_, BigEndian>(
         &BTreeMap::<usize, usize>::new(),
-        Infinite,
+        None,
     ));
 
     check_error_kind(cdr::de::deserialize_data::<Option<usize>, BigEndian>(


### PR DESCRIPTION
i've been playing around with simplifying by removing the 'SizeLimit' trait, and using an `Option<u64>` instead

this removes around 100 lines of code, and reduces the complexity of the trait bounds