### PR TITLE
migrate to criterion for benchmarking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.56.1"
-      - run: cargo check
+      - run: cargo check --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.56.1"
+          toolchain: "1.60.0"
       - run: cargo check --lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,9 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 bincode = "1.3.3"
+criterion = "0.5.1"
 serde_derive = "1.0.164"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 keywords = ["encode", "decode", "serialize", "deserialize"]
 categories = ["encoding", "network-programming"]
 license = "MIT/Apache-2.0"
-edition = "2018"
-rust-version = "1.56.1"
+edition = "2021"
+rust-version = "1.60.0"
 
 [dependencies]
 byteorder = "1.4.3"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,7 +21,7 @@ struct MsgInfo {
 }
 
 #[repr(C)]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 struct LidarPoint {
     position: [f32; 3],
     intensity: u8,
@@ -33,16 +33,17 @@ fn compose_lidar_points_msg() -> LidarPointsMsg {
         timestamp: 3,
         guid: 5,
     };
-    let points = (0..10_000)
-        .map(|_| LidarPoint {
+    let points = vec![
+        LidarPoint {
             position: [
                 std::f32::EPSILON,
                 std::f32::EPSILON * 1.,
                 std::f32::EPSILON * 2.,
             ],
             intensity: 7,
-        })
-        .collect();
+        };
+        10_000
+    ];
     LidarPointsMsg { msg_info, points }
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, clippy::all)]
 
+use cdr::{BigEndian, CdrBe, Infinite};
 use criterion::{criterion_group, criterion_main, Criterion};
 use serde_derive::{Deserialize, Serialize};
 
@@ -46,27 +47,23 @@ fn compose_lidar_points_msg() -> LidarPointsMsg {
 }
 
 fn lidar_point_msg(b: &mut Criterion) {
-    use cdr::{CdrBe, Infinite};
-
     let msg = compose_lidar_points_msg();
     b.bench_function("lidar point msg", |b| {
         b.iter(|| {
             let encoded = cdr::serialize::<_, _, CdrBe>(&msg, Infinite).unwrap();
-            let _decoded = cdr::deserialize::<LidarPointsMsg>(&encoded[..]).unwrap();
-        })
+            let _decoded = cdr::deserialize::<LidarPointsMsg>(&encoded).unwrap();
+        });
     });
 }
 
 fn lidar_point_msg_without_encapsulation(b: &mut Criterion) {
-    use cdr::{BigEndian, Infinite};
-
     let msg = compose_lidar_points_msg();
     b.bench_function("lidar point msg without encapsulation", |b| {
         b.iter(|| {
             let encoded = cdr::ser::serialize_data::<_, _, BigEndian>(&msg, Infinite).unwrap();
             let _decoded =
-                cdr::de::deserialize_data::<LidarPointsMsg, BigEndian>(&encoded[..]).unwrap();
-        })
+                cdr::de::deserialize_data::<LidarPointsMsg, BigEndian>(&encoded).unwrap();
+        });
     });
 }
 
@@ -75,97 +72,87 @@ fn lidar_point_msg_bincode(b: &mut Criterion) {
     b.bench_function("lidar point msg bincode", |b| {
         b.iter(|| {
             let encoded = bincode::serialize(&msg).unwrap();
-            let _decoded = bincode::deserialize::<LidarPointsMsg>(&encoded[..]).unwrap();
-        })
+            let _decoded = bincode::deserialize::<LidarPointsMsg>(&encoded).unwrap();
+        });
     });
 }
 
-fn compose_string_msg() -> String {
-    r#"What's he that wishes so?
-My cousin Westmoreland? No, my fair cousin:
-If we are mark'd to die, we are enow
-To do our country loss; and if to live,
-The fewer men, the greater share of honour.
-God's will! I pray thee, wish not one man more.
-By Jove, I am not covetous for gold,
-Nor care I who doth feed upon my cost;
-It yearns me not if men my garments wear;
-Such outward things dwell not in my desires:
-But if it be a sin to covet honour,
-I am the most offending soul alive.
-No, faith, my coz, wish not a man from England:
-God's peace! I would not lose so great an honour
-As one man more, methinks, would share from me
-For the best hope I have. O, do not wish one more!
-Rather proclaim it, Westmoreland, through my host,
-That he which hath no stomach to this fight,
-Let him depart; his passport shall be made
-And crowns for convoy put into his purse:
-We would not die in that man's company
-That fears his fellowship to die with us.
-This day is called the feast of Crispian:
-He that outlives this day, and comes safe home,
-Will stand a tip-toe when the day is named,
-And rouse him at the name of Crispian.
-He that shall live this day, and see old age,
-Will yearly on the vigil feast his neighbours,
-And say 'To-morrow is Saint Crispian:'
-Then will he strip his sleeve and show his scars.
-And say 'These wounds I had on Crispin's day.'
-Old men forget: yet all shall be forgot,
-But he'll remember with advantages
-What feats he did that day: then shall our names.
-Familiar in his mouth as household words
-Harry the king, Bedford and Exeter,
-Warwick and Talbot, Salisbury and Gloucester,
-Be in their flowing cups freshly remember'd.
-This story shall the good man teach his son;
-And Crispin Crispian shall ne'er go by,
-From this day to the ending of the world,
-But we in it shall be remember'd;
-We few, we happy few, we band of brothers;
-For he to-day that sheds his blood with me
-Shall be my brother; be he ne'er so vile,
-This day shall gentle his condition:
-And gentlemen in England now a-bed
-Shall think themselves accursed they were not here,
-And hold their manhoods cheap whiles any speaks
-That fought with us upon Saint Crispin's day.
-"#
-    .into()
-}
+const MSG: &str = r#"What's he that wishes so?
+    My cousin Westmoreland? No, my fair cousin:
+    If we are mark'd to die, we are enow
+    To do our country loss; and if to live,
+    The fewer men, the greater share of honour.
+    God's will! I pray thee, wish not one man more.
+    By Jove, I am not covetous for gold,
+    Nor care I who doth feed upon my cost;
+    It yearns me not if men my garments wear;
+    Such outward things dwell not in my desires:
+    But if it be a sin to covet honour,
+    I am the most offending soul alive.
+    No, faith, my coz, wish not a man from England:
+    God's peace! I would not lose so great an honour
+    As one man more, methinks, would share from me
+    For the best hope I have. O, do not wish one more!
+    Rather proclaim it, Westmoreland, through my host,
+    That he which hath no stomach to this fight,
+    Let him depart; his passport shall be made
+    And crowns for convoy put into his purse:
+    We would not die in that man's company
+    That fears his fellowship to die with us.
+    This day is called the feast of Crispian:
+    He that outlives this day, and comes safe home,
+    Will stand a tip-toe when the day is named,
+    And rouse him at the name of Crispian.
+    He that shall live this day, and see old age,
+    Will yearly on the vigil feast his neighbours,
+    And say 'To-morrow is Saint Crispian:'
+    Then will he strip his sleeve and show his scars.
+    And say 'These wounds I had on Crispin's day.'
+    Old men forget: yet all shall be forgot,
+    But he'll remember with advantages
+    What feats he did that day: then shall our names.
+    Familiar in his mouth as household words
+    Harry the king, Bedford and Exeter,
+    Warwick and Talbot, Salisbury and Gloucester,
+    Be in their flowing cups freshly remember'd.
+    This story shall the good man teach his son;
+    And Crispin Crispian shall ne'er go by,
+    From this day to the ending of the world,
+    But we in it shall be remember'd;
+    We few, we happy few, we band of brothers;
+    For he to-day that sheds his blood with me
+    Shall be my brother; be he ne'er so vile,
+    This day shall gentle his condition:
+    And gentlemen in England now a-bed
+    Shall think themselves accursed they were not here,
+    And hold their manhoods cheap whiles any speaks
+    That fought with us upon Saint Crispin's day.
+    "#;
 
 fn string_msg(b: &mut Criterion) {
-    use cdr::{CdrBe, Infinite};
-
-    let msg = compose_string_msg();
     b.bench_function("string msg", |b| {
         b.iter(|| {
-            let encoded = cdr::serialize::<_, _, CdrBe>(&msg, Infinite).unwrap();
-            let _decoded = cdr::deserialize::<String>(&encoded[..]).unwrap();
-        })
+            let encoded = cdr::serialize::<_, _, CdrBe>(MSG, Infinite).unwrap();
+            let _decoded = cdr::deserialize::<String>(&encoded).unwrap();
+        });
     });
 }
 
 fn string_msg_without_encapsulation(b: &mut Criterion) {
-    use cdr::{BigEndian, Infinite};
-
-    let msg = compose_string_msg();
     b.bench_function("string msg without encapsulation", |b| {
         b.iter(|| {
-            let encoded = cdr::ser::serialize_data::<_, _, BigEndian>(&msg, Infinite).unwrap();
-            let _decoded = cdr::de::deserialize_data::<String, BigEndian>(&encoded[..]).unwrap();
-        })
+            let encoded = cdr::ser::serialize_data::<_, _, BigEndian>(MSG, Infinite).unwrap();
+            let _decoded = cdr::de::deserialize_data::<String, BigEndian>(&encoded).unwrap();
+        });
     });
 }
 
 fn string_msg_bincode(b: &mut Criterion) {
-    let msg = compose_string_msg();
     b.bench_function("string msg bincode", |b| {
         b.iter(|| {
-            let encoded = bincode::serialize(&msg).unwrap();
-            let _decoded = bincode::deserialize::<String>(&encoded[..]).unwrap();
-        })
+            let encoded = bincode::serialize(MSG).unwrap();
+            let _decoded = bincode::deserialize::<String>(&encoded).unwrap();
+        });
     });
 }
 


### PR DESCRIPTION
migrates to criterion, a much more full-featured benchmarking harness.

Among other things, criterion provides

- confidence intervals for benchmarking results
- easy comparison between branches
- HTML reports (optionally)